### PR TITLE
Allow encoding multiple of the same hero

### DIFF
--- a/lib/deck/encode.js
+++ b/lib/deck/encode.js
@@ -34,7 +34,7 @@ const addRemaniningBits = (value, written, buffer) => {
 };
 
 const addCardToBuffer = (countOrTurn, value, buffer) => {
-  if (!countOrTurn || value <= 0) {
+  if (!countOrTurn || value < 0) {
     return false;
   }
 

--- a/test/decode.js
+++ b/test/decode.js
@@ -1,6 +1,7 @@
 const { assert } = require('chai');
 const { decode } = require('../lib');
 const greenBlackDeck = require('./green-black');
+const multipleSameHero = require('./multiple-same-hero');
 
 describe('Decoding Artifact Deck Code', () => {
   it('should fail without correct prefix', () => {
@@ -9,8 +10,12 @@ describe('Decoding Artifact Deck Code', () => {
 
   it('should correctly return deck', () => {
     const res = decode('ADCJWkTZX05uwGDCRV4XQGy3QGLmqUBg4GQJgGLGgO7AaABR3JlZW4vQmxhY2sgRXhhbXBsZQ__');
-
     assert.deepEqual(res, greenBlackDeck);
+  });
+
+  it('should correctly decode multiple of the same hero', () => {
+    const res = decode('ADCJZ8ZZLkCAIAAAE11bHRpcGxlIG9mIHRoZSBzYW1lIGhlcm8_');
+    assert.deepEqual(res, multipleSameHero);
   });
 
   it('should fail with bad version', () => {

--- a/test/encode.js
+++ b/test/encode.js
@@ -1,6 +1,7 @@
 const { assert } = require('chai');
 const { encode } = require('../lib');
 const greenBlackDeck = require('./green-black');
+const multipleSameHero = require('./multiple-same-hero');
 
 describe('Encoding Artifact Deck Code', () => {
   it('should fail when encoding non-object', () => {
@@ -19,5 +20,9 @@ describe('Encoding Artifact Deck Code', () => {
 
   it('should succeed', () => {
     assert.equal(encode(greenBlackDeck), 'ADCJWkTZX05uwGDCRV4XQGy3QGLmqUBg4GQJgGLGgO7AaABR3JlZW4vQmxhY2sgRXhhbXBsZQ__');
+  });
+
+  it('should successfully encode multiple of the same hero', () => {
+    assert.equal(encode(multipleSameHero), 'ADCJZ8ZZLkCAIAAAE11bHRpcGxlIG9mIHRoZSBzYW1lIGhlcm8_');
   });
 });

--- a/test/multiple-same-hero.js
+++ b/test/multiple-same-hero.js
@@ -1,0 +1,26 @@
+module.exports = {
+  name: "Multiple of the same hero",
+  heroes: [
+    {
+      id: 10020, // Axe
+      turn: 2
+    },
+    {
+      id: 10020, // Axe
+      turn: 1
+    },
+    {
+      id: 10020, // Axe
+      turn: 3
+    },
+    {
+      id: 10020, // Axe
+      turn: 1
+    },
+    {
+      id: 10020, // Axe
+      turn: 1
+    }
+  ],
+  cards: []
+};


### PR DESCRIPTION
Hi friends, thanks for getting this project started!

We're evaluating the use of this library on [Artibuff](https://www.artibuff.com) and noticed that the deck encoder was failing to encode more than one of the same hero. The game allows this, a necessity for building some draft decks.

https://playartifact.com/d/ADCJZ8ZZLkCAIAAAE11bHRpcGxlIG9mIHRoZSBzYW1lIGhlcm8_

Thankfully it's a simple patch, supplied along with a test case.

